### PR TITLE
feat: add pitch wrap

### DIFF
--- a/project/mods/MidiStrummer/main.gd
+++ b/project/mods/MidiStrummer/main.gd
@@ -19,7 +19,10 @@ func _input(event: InputEvent) -> void:
 
 	var pitch: int = event.pitch
 	if !_is_pitch_in_bounds(pitch):
-		return
+		while pitch < OPEN_STRING_PITCHES[0]:
+			pitch += 12
+		while pitch > OPEN_STRING_PITCHES[5] + HIGHEST_FRET:
+			pitch -= 12
 
 	var possible_notes := _get_possible_notes(pitch)
 	var note := _get_best_note(possible_notes)


### PR DESCRIPTION
Notes outside the guitar's range are currently ignored, and this change causes them to be shifted by octaves until they are within the guitar's range. This may make some music sections sound strange, but I think that's better than those sections not getting played at all.